### PR TITLE
Increase the presence of a detection file when writing a log

### DIFF
--- a/rotatelogs.go
+++ b/rotatelogs.go
@@ -112,8 +112,12 @@ func (rl *RotateLogs) getWriter_nolock(bailOnRotateFail bool) (io.Writer, error)
 	// to log to, which may be newer than rl.currentFilename
 	filename := rl.genFilename()
 	if rl.curFn == filename {
-		// nothing to do
-		return rl.outFh, nil
+		//Increase the judgment file to exist
+		_, err := os.Stat(filename)
+		if err == nil {
+			// nothing to do
+			return rl.outFh, nil
+		}
 	}
 
 	// if we got here, then we need to create a file


### PR DESCRIPTION


After the program is started, the log files are deleted manually, but no files are written.
So, Increase the presence of a detection file when writing a log