### PR TITLE
Make `Rotate` generate unique filenames in case of a name clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,28 @@ Note: MaxAge should be disabled by specifing `WithMaxAge(-1)` explicitly.
     rotatelogs.WithRotationCount(7),
   )
 ```
+
+# Rotating files forcefully
+
+If you want to rotate files forcefully before the actual rotation time has reached,
+you may use the `Rotate()` method. This method forcefully rotates the logs, but
+if the generated file name clashes, then a numeric suffix is added so that
+the new file will forcefully appear on disk.
+
+For example, suppose you had a pattern of '%Y.log' with a rotation time of
+`86400` so that it only gets rotated every year, but for whatever reason you
+wanted to rotate the logs now, you could install a signal handler to
+trigger this rotation:
+
+```go
+rl := rotatelogs.New(...)
+
+signal.Notify(ch, syscall.SIGHUP)
+
+go func(ch chan os.Signal) {
+  <-ch
+  rl.Rotate()
+}()
+```
+
+And you will get a log file name in like `2018.log.1`, `2018.log.2`, etc.

--- a/interface.go
+++ b/interface.go
@@ -14,6 +14,7 @@ type RotateLogs struct {
 	clock         Clock
 	curFn         string
 	globPattern   string
+	generation    int
 	linkName      string
 	maxAge        time.Duration
 	mutex         sync.RWMutex

--- a/rotatelogs.go
+++ b/rotatelogs.go
@@ -98,7 +98,7 @@ func (rl *RotateLogs) Write(p []byte) (n int, err error) {
 	rl.mutex.Lock()
 	defer rl.mutex.Unlock()
 
-	out, err := rl.getWriter_nolock(false)
+	out, err := rl.getWriter_nolock(false, false)
 	if err != nil {
 		return 0, errors.Wrap(err, `failed to acquite target io.Writer`)
 	}
@@ -107,13 +107,31 @@ func (rl *RotateLogs) Write(p []byte) (n int, err error) {
 }
 
 // must be locked during this operation
-func (rl *RotateLogs) getWriter_nolock(bailOnRotateFail bool) (io.Writer, error) {
+func (rl *RotateLogs) getWriter_nolock(bailOnRotateFail, useGenerationalNames bool) (io.Writer, error) {
+	generation := rl.generation
+
 	// This filename contains the name of the "NEW" filename
 	// to log to, which may be newer than rl.currentFilename
 	filename := rl.genFilename()
-	if rl.curFn == filename {
-		// nothing to do
-		return rl.outFh, nil
+	if rl.curFn != filename {
+		generation = 0
+	} else {
+		if !useGenerationalNames {
+			// nothing to do
+			return rl.outFh, nil
+		}
+		// This is used when we *REALLY* want to rotate a log.
+		// instead of just using the regular strftime pattern, we
+		// create a new file name using generational names such as
+		// "foo.1", "foo.2", "foo.3", etc
+		for {
+			generation++
+			name := fmt.Sprintf("%s.%d", filename, generation)
+			if _, err := os.Stat(name); err != nil {
+				filename = name
+				break
+			}
+		}
 	}
 
 	// if we got here, then we need to create a file
@@ -137,6 +155,7 @@ func (rl *RotateLogs) getWriter_nolock(bailOnRotateFail bool) (io.Writer, error)
 	rl.outFh.Close()
 	rl.outFh = fh
 	rl.curFn = filename
+	rl.generation = generation
 
 	return fh, nil
 }
@@ -169,11 +188,17 @@ func (g *cleanupGuard) Run() {
 	g.fn()
 }
 
-// Rotate forcefully rotates the log files.
+// Rotate forcefully rotates the log files. If the generated file name
+// clash because file already exists, a numeric suffix of the form
+// ".1", ".2", ".3" and so forth are appended to the end of the log file
+//
+// Thie method can be used in conjunction with a signal handler so to
+// emulate servers that generate new log files when they receive a
+// SIGHUP
 func (rl *RotateLogs) Rotate() error {
 	rl.mutex.Lock()
 	defer rl.mutex.Unlock()
-	if _, err := rl.getWriter_nolock(true); err != nil {
+	if _, err := rl.getWriter_nolock(true, true); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Without this, you still can't really Rotate manually.