### PR TITLE
Create directory if it does not already exist

### DIFF
--- a/rotatelogs.go
+++ b/rotatelogs.go
@@ -154,7 +154,13 @@ func (rl *RotateLogs) getWriter_nolock(bailOnRotateFail, useGenerationalNames bo
 			}
 		}
 	}
-
+	// make sure the dir is existed, eg:
+	// ./foo/bar/baz/hello.log must make sure ./foo/bar/baz is existed
+	dirname := filepath.Dir(filename)
+	err := os.MkdirAll(dirname, os.ModePerm)
+	if nil != err {
+		return nil, errors.Errorf("failed to create directory %s: %s", dirname, err)
+	}
 	// if we got here, then we need to create a file
 	fh, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {

--- a/rotatelogs.go
+++ b/rotatelogs.go
@@ -157,9 +157,8 @@ func (rl *RotateLogs) getWriter_nolock(bailOnRotateFail, useGenerationalNames bo
 	// make sure the dir is existed, eg:
 	// ./foo/bar/baz/hello.log must make sure ./foo/bar/baz is existed
 	dirname := filepath.Dir(filename)
-	err := os.MkdirAll(dirname, os.ModePerm)
-	if nil != err {
-		return nil, errors.Errorf("failed to create directory %s: %s", dirname, err)
+	if err := os.MkdirAll(dirname, 0755); err != nil {
+		return nil, errors.Wrapf(err, "failed to create directory %s", dirname)
 	}
 	// if we got here, then we need to create a file
 	fh, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)


### PR DESCRIPTION
Case: 
```
        logf, err := rotatelogs.New(
                "./foo/bar.log.%Y%m%d%H",
                rotatelogs.WithLinkName("./foo/bar.log"),
                rotatelogs.WithMaxAge(24*time.Hour),
                rotatelogs.WithRotationTime(time.Hour),
        )
```
and when the ./foo directory isn't existed, error occur!
```
open ./foo/bar.log.2018101616: no such file or directory
```
We must ensure that the dir is existed by doing so can we use os.OpenFile to create or append the filename