### PR TITLE
After a forced generational rotate, ensure new writes go to the new file.

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -35,6 +35,7 @@ type FileRotatedEvent struct {
 type RotateLogs struct {
 	clock         Clock
 	curFn         string
+	curBaseFn     string
 	globPattern   string
 	generation    int
 	linkName      string

--- a/rotatelogs.go
+++ b/rotatelogs.go
@@ -133,8 +133,9 @@ func (rl *RotateLogs) getWriter_nolock(bailOnRotateFail, useGenerationalNames bo
 	previousFn := rl.curFn
 	// This filename contains the name of the "NEW" filename
 	// to log to, which may be newer than rl.currentFilename
-	filename := rl.genFilename()
-	if previousFn != filename {
+	baseFn := rl.genFilename()
+	filename := baseFn
+	if baseFn != rl.curBaseFn {
 		generation = 0
 	} else {
 		if !useGenerationalNames {
@@ -186,6 +187,7 @@ func (rl *RotateLogs) getWriter_nolock(bailOnRotateFail, useGenerationalNames bo
 
 	rl.outFh.Close()
 	rl.outFh = fh
+	rl.curBaseFn = baseFn
 	rl.curFn = filename
 	rl.generation = generation
 


### PR DESCRIPTION
Keep track of the base filename for log files, so when a forced
generational rotate is performed, the existing log file becomes a
new version and subsequent writes go to the new file.