### PR TITLE
Add an option to New that will always create a new file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,30 @@ object. Currently only supported event type is FiledRotated
   )
 ```
 
+## ForceNewFile
+
+Ensure a new file is created every time New() is called. If the base file name
+already exists, an implicit rotation is performed.
+
+```go
+  rotatelogs.New(
+    "/var/log/myapp/log.%Y%m%d",
+    rotatelogs.ForceNewFile(),
+  )
+```
+
+## ForceNewFile
+
+Ensure a new file is created every time New() is called. If the base file name
+already exists, an implicit rotation is performed.
+
+```go
+  rotatelogs.New(
+    "/var/log/myapp/log.%Y%m%d",
+    rotatelogs.ForceNewFile(),
+  )
+```
+
 # Rotating files forcefully
 
 If you want to rotate files forcefully before the actual rotation time has reached,

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,56 @@
+package rotatelogs_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	rotatelogs "github.com/lestrrat-go/file-rotatelogs"
+)
+
+func ExampleForceNewFile () {
+	logDir, err := ioutil.TempDir("", "rotatelogs_test")
+	if err != nil {
+		fmt.Println("could not create log directory ", err)
+		return
+	}
+	logPath := fmt.Sprintf("%s/test.log", logDir)
+
+	for i := 0; i < 2; i++ {
+		writer, err := rotatelogs.New(logPath,
+			rotatelogs.ForceNewFile(),
+		)
+		if err != nil {
+			fmt.Println("Could not open log file ", err)
+			return
+		}
+
+		n, err := writer.Write([]byte("test"))
+		if err != nil || n != 4 {
+			fmt.Println("Write failed ", err, " number written ", n)
+			return
+		}
+		err = writer.Close()
+		if err != nil {
+			fmt.Println("Close failed ", err)
+			return
+		}
+	}
+
+	files, err := ioutil.ReadDir(logDir)
+	if err != nil {
+		fmt.Println("ReadDir failed ", err)
+		return
+	}
+	for _, file := range files {
+		fmt.Println(file.Name(), file.Size())
+	}
+
+	err = os.RemoveAll(logDir)
+	if err != nil {
+		fmt.Println("RemoveAll failed ", err)
+		return
+	}
+	// OUTPUT:
+	// test.log 4
+	// test.log.1 4
+}

--- a/interface.go
+++ b/interface.go
@@ -46,6 +46,7 @@ type RotateLogs struct {
 	pattern       *strftime.Strftime
 	rotationTime  time.Duration
 	rotationCount uint
+	forceNewFile  bool
 }
 
 // Clock is the interface used by the RotateLogs

--- a/options.go
+++ b/options.go
@@ -13,6 +13,7 @@ const (
 	optkeyMaxAge        = "max-age"
 	optkeyRotationTime  = "rotation-time"
 	optkeyRotationCount = "rotation-count"
+	optkeyForceNewFile  = "force-new-file"
 )
 
 // WithClock creates a new Option that sets a clock
@@ -71,4 +72,11 @@ func WithRotationCount(n uint) Option {
 // Currently `FileRotated` event is supported
 func WithHandler(h Handler) Option {
 	return option.New(optkeyHandler, h)
+}
+
+// ForceNewFile ensures a new file is created every time New()
+// is called. If the base file name already exists, an implicit 
+// rotation is performed
+func ForceNewFile() Option {
+	return option.New(optkeyForceNewFile, true)
 }


### PR DESCRIPTION
The rotatelogs.ForceNewFile() option to New() always creates a new
file. If the base file name exists, a versioned file is created.