### PR TITLE
set link to relative path file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 sudo: false
 go:
-  - "1.10"
+  - "1.14"
   - tip

--- a/rotatelogs.go
+++ b/rotatelogs.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -280,7 +279,11 @@ func (rl *RotateLogs) rotate_nolock(filename string) error {
 
 	if rl.linkName != "" {
 		tmpLinkName := filename + `_symlink`
-		if err := os.Symlink(path.Base(filename), tmpLinkName); err != nil {
+		linkDest := filename
+		if filepath.Dir(rl.linkName) == filepath.Dir(filename) {
+			linkDest = filepath.Base(filename)
+		}
+		if err := os.Symlink(linkDest, tmpLinkName); err != nil {
 			return errors.Wrap(err, `failed to create new symlink`)
 		}
 

--- a/rotatelogs.go
+++ b/rotatelogs.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -279,7 +280,7 @@ func (rl *RotateLogs) rotate_nolock(filename string) error {
 
 	if rl.linkName != "" {
 		tmpLinkName := filename + `_symlink`
-		if err := os.Symlink(filename, tmpLinkName); err != nil {
+		if err := os.Symlink(path.Base(filename), tmpLinkName); err != nil {
 			return errors.Wrap(err, `failed to create new symlink`)
 		}
 

--- a/rotatelogs_test.go
+++ b/rotatelogs_test.go
@@ -124,7 +124,7 @@ func TestLogRotate(t *testing.T) {
 	}
 
 	if linkDest != path.Base(newfn) {
-		t.Errorf(`Symlink destination does not match expected filename ("%s" != "%s")`, newfn, linkDest)
+		t.Errorf(`Symlink destination does not match expected filename ("%s" != "%s")`, path.Base(newfn), linkDest)
 	}
 }
 

--- a/rotatelogs_test.go
+++ b/rotatelogs_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -122,7 +123,7 @@ func TestLogRotate(t *testing.T) {
 		t.Errorf("Failed to readlink %s: %s", linkName, err)
 	}
 
-	if linkDest != newfn {
+	if linkDest != path.Base(newfn) {
 		t.Errorf(`Symlink destination does not match expected filename ("%s" != "%s")`, newfn, linkDest)
 	}
 }

--- a/rotatelogs_test.go
+++ b/rotatelogs_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -123,8 +122,12 @@ func TestLogRotate(t *testing.T) {
 		t.Errorf("Failed to readlink %s: %s", linkName, err)
 	}
 
-	if linkDest != path.Base(newfn) {
-		t.Errorf(`Symlink destination does not match expected filename ("%s" != "%s")`, path.Base(newfn), linkDest)
+	expectedLinkDest := newfn
+	if filepath.Dir(newfn) == filepath.Dir(linkName) {
+		expectedLinkDest = filepath.Base(newfn)
+	}
+	if linkDest != expectedLinkDest {
+		t.Errorf(`Symlink destination does not match expected filename ("%s" != "%s")`, expectedLinkDest, linkDest)
 	}
 }
 


### PR DESCRIPTION
```
logf := rotatelogs.New(
		"/var/log/xxx/runtime.%Y%m%d",
		rotatelogs.WithLinkName("/var/log/xxx/runtime"), 
		rotatelogs.WithRotationTime(24*time.Hour),
		rotatelogs.WithMaxAge(24*time.Hour*7),
	)
```
if my go app run in docker,with volume mount like this:
```
volumes:
 - hostPath:
      path: /var/lib/k8s/log/xxx
      type: File
    name: log
volumeMounts:
- mountPath: /var/log/xxx
  name: log
```
and when i go to the container's hypervisor, going to the path /var/lib/k8s/log/xxx, link file runtime cannot open(error: No such file or directory.) since the link file linked /var/log/xxx/runtime.%Y%m%d which is in the container path  not the hypervisor path.  

So we need make the link file link to relative path. And I see the k8s log link file also link to relative path. 
```
kube-apiserver.INFO -> kube-apiserver.MASTER1.root.log.INFO.20200814-101251.2053

```